### PR TITLE
Add missing tf2_geometry_msgs dependency.

### DIFF
--- a/roverrobotics_driver/CMakeLists.txt
+++ b/roverrobotics_driver/CMakeLists.txt
@@ -13,6 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf2
   pluginlib
   nav_msgs
+  tf2_geometry_msgs
 )
 
 catkin_package(

--- a/roverrobotics_driver/package.xml
+++ b/roverrobotics_driver/package.xml
@@ -19,6 +19,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>tf2</build_depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>pluginlib</build_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>


### PR DESCRIPTION
Try building the package without having tf2_geometry_msgs installed via apt or compiled in your catkin_ws, it fails. 

Resolution: Add missing dependency, tf2_geometry_msgs. Reproduce: 