### PR TITLE
Odom message fix

### DIFF
--- a/roverrobotics_driver/src/roverrobotics_ros_driver.cpp
+++ b/roverrobotics_driver/src/roverrobotics_ros_driver.cpp
@@ -277,6 +277,7 @@ void RobotDriver::publishOdometry(const ros::TimerEvent &event) {
   odom_msg.header.stamp = ros::Time::now();
   odom_msg.header.frame_id = "odom";
   odom_msg.child_frame_id = "base_link";
+  odom_msg.pose.pose.orientation.w = 1.0;
   odom_msg.twist.twist.linear.x = data.linear_vel;
   odom_msg.twist.twist.angular.z = data.angular_vel;
   robot_odom_publisher_.publish(odom_msg);


### PR DESCRIPTION
Added orientation to the odom message, otherwise the resulting quaternion is invalid.