### PR TITLE
Add odometry frame parameters

### DIFF
--- a/roverrobotics_driver/include/roverrobotics_ros_driver.hpp
+++ b/roverrobotics_driver/include/roverrobotics_ros_driver.hpp
@@ -45,7 +45,7 @@ class RobotDriver {
   std::string estop_reset_topic_;
   std::string robot_status_topic_;
   std::string odom_frame_id_;
-  std::string odom_child_frame_id;
+  std::string odom_child_frame_id_;
   float robot_status_frequency_;
   float robot_odom_frequency_;
   std::string robot_info_request_topic_;

--- a/roverrobotics_driver/include/roverrobotics_ros_driver.hpp
+++ b/roverrobotics_driver/include/roverrobotics_ros_driver.hpp
@@ -44,6 +44,8 @@ class RobotDriver {
   std::string mode_trigger_topic_;
   std::string estop_reset_topic_;
   std::string robot_status_topic_;
+  std::string odom_frame_id_;
+  std::string odom_child_frame_id;
   float robot_status_frequency_;
   float robot_odom_frequency_;
   std::string robot_info_request_topic_;
@@ -79,6 +81,8 @@ class RobotDriver {
   const float ROBOT_ODOM_FREQUENCY_DEFAULT_ = 30.00;
   const float ODOM_ANGULAR_COEF_DEFAULT_ = 0;
   const float ODOM_TRCTION_FACTOR_DEFAULT_ = 0;
+  const std::string ODOM_FRAME_ID_DEFAULT_ = "odom";
+  const std::string ODOM_CHILD_FRAME_ID_DEFAULT_ = "base_link";
   const float ANGULAR_SCALING_A_DEFAULT_ = 0;
   const float ANGULAR_SCALING_B_DEFAULT_ = 0;
   const float ANGULAR_SCALING_C_DEFAULT_ = 0;

--- a/roverrobotics_driver/src/roverrobotics_ros_driver.cpp
+++ b/roverrobotics_driver/src/roverrobotics_ros_driver.cpp
@@ -298,8 +298,8 @@ void RobotDriver::publishOdometry(const ros::TimerEvent &event) {
   tf2::Quaternion q_new;
 
   odom_msg.header.stamp = ros::Time::now();
-  odom_msg.header.frame_id = "odom";
-  odom_msg.child_frame_id = "base_link";
+  odom_msg.header.frame_id = odom_frame_id_;
+  odom_msg.child_frame_id = odom_child_frame_id_;
 
   // Calculate time
   ros::Time ros_now_time = ros::Time::now();

--- a/roverrobotics_driver/src/roverrobotics_ros_driver.cpp
+++ b/roverrobotics_driver/src/roverrobotics_ros_driver.cpp
@@ -125,6 +125,19 @@ RobotDriver::RobotDriver(ros::NodeHandle *nh) {
     ros::shutdown();
     return;
   }
+  
+  // Odom frame and Child frame params
+  if (!ros::param::get("odom_frame", odom_frame_id_)) {
+    ROS_INFO("no 'odom_frame_id_' set; using the default value: %f",
+             ODOM_FRAME_ID_DEFAULT_);
+    odom_frame_id_ = ODOM_FRAME_ID_DEFAULT_;
+  }
+  if (!ros::param::get("odom_child_frame", odom_child_frame_id_)) {
+    ROS_INFO("no 'odom_child_frame_id_' set; using the default value: %f",
+             ODOM_CHILD_FRAME_ID_DEFAULT_);
+    odom__child_frame_id_ = ODOM_CHILD_FRAME_ID_DEFAULT_;
+  }
+
 
   // Check if launch files have parameters set; Otherwise use hardcoded values
   if (!ros::param::get("trim_topic", trim_topic_)) {


### PR DESCRIPTION
Adds the option to change odometry frame names via parameters.

Frame Parameters:
"odom_frame": Changes the odometry frame name. Default "odom"
"odom_child_frame": Changes the child frame to odom. Default "base_link"